### PR TITLE
Give more data to renderers

### DIFF
--- a/aspen/renderers/__init__.py
+++ b/aspen/renderers/__init__.py
@@ -86,7 +86,7 @@ from __future__ import unicode_literals
 
 class Renderer(object):
 
-    def __init__(self, factory, filepath, raw):
+    def __init__(self, factory, filepath, raw, media_type, offset):
         """Takes a Factory and two bytestrings.
         """
         self._filepath = filepath
@@ -94,6 +94,8 @@ class Renderer(object):
         self._changes_reload = factory._changes_reload
         self.meta = self._factory.meta
         self.raw = raw
+        self.media_type = media_type
+        self.offset = offset
         self.compiled = self.compile(self._filepath, self.raw)
 
     def __call__(self, context):
@@ -136,11 +138,11 @@ class Factory(object):
         self._changes_reload = configuration.changes_reload
         self.meta = self.compile_meta(configuration)
 
-    def __call__(self, filepath, raw):
+    def __call__(self, filepath, raw, media_type, offset):
         """Given two bytestrings, return a callable.
         """
         self._update_meta()
-        return self.Renderer(self, filepath, raw)
+        return self.Renderer(self, filepath, raw, media_type, offset)
 
     def _update_meta(self):
         if self._changes_reload:

--- a/aspen/renderers/__init__.py
+++ b/aspen/renderers/__init__.py
@@ -29,12 +29,14 @@ instantied with one argument:
     configuration   an Aspen configuration object
 
 
-Instances of each Renderer subclass are callables that take three arguments and
-return a function (confused yet?). The three arguments are:
+Instances of each Renderer subclass are callables that take five arguments and
+return a function (confused yet?). The five arguments are:
 
     factory         the Factory creating this object
     filepath        the filesystem path of the resource in question
     raw             the bytestring of the page of the resource in question
+    media_type      the media type of the page
+    offset          the line number at which the page starts
 
 
 Each Renderer instance is a callable that takes a context dictionary and
@@ -87,7 +89,7 @@ from __future__ import unicode_literals
 class Renderer(object):
 
     def __init__(self, factory, filepath, raw, media_type, offset):
-        """Takes a Factory and two bytestrings.
+        """Takes a Factory, three bytestrings, and an int.
         """
         self._filepath = filepath
         self._factory = factory
@@ -124,6 +126,8 @@ class Renderer(object):
             self.compiled   the result of self.compile (generally a template in
                              compiled object form)
             self.meta       the result of Factory.compile_meta
+            self.media_type the media type of the page
+            self.offset     the line number at which the page starts
 
         """
         return self.raw  # pass-through
@@ -139,7 +143,7 @@ class Factory(object):
         self.meta = self.compile_meta(configuration)
 
     def __call__(self, filepath, raw, media_type, offset):
-        """Given two bytestrings, return a callable.
+        """Given three bytestrings and an int, return a callable.
         """
         self._update_meta()
         return self.Renderer(self, filepath, raw, media_type, offset)

--- a/aspen/resources/simplate.py
+++ b/aspen/resources/simplate.py
@@ -141,7 +141,7 @@ class Simplate(Resource):
         _parse_specline = self._bound_parse_specline \
                             if self.is_bound else self._unbound_parse_specline
         make_renderer, media_type = _parse_specline(page.header)
-        renderer = make_renderer(self.fs, page.content)
+        renderer = make_renderer(self.fs, page.content, media_type, page.offset)
         if media_type in self.renderers:
             raise SyntaxError("Two content pages defined for %s." % media_type)
 

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from aspen import json
+from aspen.renderers import Factory, Renderer
+
+
+def test_a_custom_renderer(harness):
+    class TestRenderer(Renderer):
+
+        def compile(self, *a):
+            return self.raw.upper()
+
+        def render_content(self, context):
+            d = dict((k, v) for k, v in self.__dict__.items() if k[0] != '_')
+            return json.dumps(d)
+
+    class TestFactory(Factory):
+        Renderer = TestRenderer
+
+        def compile_meta(self, configuration):
+            return 'foobar'
+
+    website = harness.client.website
+    website.renderer_factories['lorem'] = TestFactory(website)
+
+    r = harness.simple("[---]\n[---] text/html via lorem\nLorem ipsum")
+    d = json.loads(r.body)
+    assert d['meta'] == 'foobar'
+    assert d['raw'] == 'Lorem ipsum'
+    assert d['media_type'] == 'text/html'
+    assert d['offset'] == 2
+    assert d['compiled'] == 'LOREM IPSUM'


### PR DESCRIPTION
Currently renderers only get the path of the simplate (`filepath`) and the content of the page (`raw`). It would be useful if they also got the content type (so they can determine the appropriate escaping rules for example, cf gratipay/aspen-python-plugins#9) and the position of the page in the simplate (so error messages can use the correct line numbers).

This PR makes the `offset` and `media_type` variables accessible to renderers.