### PR TITLE
Fix build scripts to work with python3

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function, unicode_literals, with_statement
+
 import os
 import sys
 import os.path
@@ -60,7 +62,7 @@ def _env(envdir='env'):
 def aspen():
     _env()
     v = shell(_virt('python'), '-c', 'import aspen; print("found")', ignore_status=True)
-    if "found" in v:
+    if b"found" in v:
         return
     for dep in ASPEN_DEPS:
         run(_virt('pip'), 'install', '--no-index',


### PR DESCRIPTION
Backstory: python3 has been the default python interpreter on ArchLinux for a long time, so programs that rely on `/usr/bin/python` being python2 fail miserably. Aspen's `Makefile` and `build.py` are such programs and thus don't work out-of-the-box on my system. I could have simply modified them to call python2, but making the code python3-compatible is better in the long run, so that's what I did.

Upstream issue: https://code.google.com/p/fabricate/issues/detail?id=38
