### PR TITLE
Use relative imports

### DIFF
--- a/aspen/__init__.py
+++ b/aspen/__init__.py
@@ -67,9 +67,9 @@ import pkg_resources
 from .backcompat import is_callable
 
 # imports of convenience
-from aspen.http.response import Response
-from aspen import json_ as json
-from aspen.logging import log, log_dammit
+from .http.response import Response
+from . import json_ as json
+from .logging import log, log_dammit
 
 # Shut up, PyFlakes. I know I'm addicted to you.
 Response, json, is_callable, log, log_dammit

--- a/aspen/__main__.py
+++ b/aspen/__main__.py
@@ -21,7 +21,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from aspen import serve, website
+from . import serve, website
 
 if __name__ == '__main__':
     serve(website.Website())

--- a/aspen/algorithms/website.py
+++ b/aspen/algorithms/website.py
@@ -39,13 +39,14 @@ from __future__ import unicode_literals
 
 import traceback
 
-import aspen
-from aspen import dispatcher, resources, body_parsers
-from aspen.http.request import Request
-from aspen.http.response import Response
-from aspen import typecasting
 from first import first as _first
-from aspen.dispatcher import DispatchResult, DispatchStatus
+
+from .. import log as _log
+from .. import log_dammit as _log_dammit
+from .. import dispatcher, resources, body_parsers, typecasting
+from ..http.request import Request
+from ..http.response import Response
+from ..dispatcher import DispatchResult, DispatchStatus
 
 
 def parse_environ_into_request(environ):
@@ -127,9 +128,9 @@ def get_response_for_exception(website, exception):
 def log_traceback_for_5xx(response, traceback=None):
     if response.code >= 500:
         if traceback:
-            aspen.log_dammit(traceback)
+            _log_dammit(traceback)
         else:
-            aspen.log_dammit(response.body)
+            _log_dammit(response.body)
     return {'traceback': None}
 
 
@@ -167,7 +168,7 @@ def delegate_error_to_simplate(website, state, response, request=None, resource=
 
 def log_traceback_for_exception(website, exception):
     tb = traceback.format_exc()
-    aspen.log_dammit(tb)
+    _log_dammit(tb)
     response = Response(500)
     if website.show_tracebacks:
         response.body = tb
@@ -213,4 +214,4 @@ def log_result_of_request(website, request=None, dispatch_result=None, response=
     # Log it.
     # =======
 
-    aspen.log("%-36s %s" % (response, msg))
+    _log("%-36s %s" % (response, msg))

--- a/aspen/auth/__init__.py
+++ b/aspen/auth/__init__.py
@@ -11,8 +11,8 @@ Currently:
     * httpdigest - HTTP DIGEST Auth
 
 """
-from aspen import Response
-from aspen.utils import typecheck
+from .. import Response
+from ..utils import typecheck
 
 
 class BaseUser(object):

--- a/aspen/auth/cookie.py
+++ b/aspen/auth/cookie.py
@@ -11,9 +11,9 @@ from __future__ import unicode_literals
 
 import datetime
 
-from aspen import auth
-from aspen.utils import to_rfc822, utcnow
-from aspen.website import THE_PAST
+from .. import auth
+from ..utils import to_rfc822, utcnow
+from ..website import THE_PAST
 
 
 MINUTE = datetime.timedelta(seconds=60)

--- a/aspen/auth/httpbasic.py
+++ b/aspen/auth/httpbasic.py
@@ -24,7 +24,7 @@ from __future__ import unicode_literals
 
 import base64
 
-from aspen import Response
+from .. import Response
 
 
 def inbound_responder(*args, **kwargs):

--- a/aspen/auth/httpdigest.py
+++ b/aspen/auth/httpdigest.py
@@ -10,7 +10,7 @@ aspen.auth.httpdigest
 
 import random, time, re
 
-from aspen.backcompat import md5
+from ..backcompat import md5
 
 class MalformedAuthenticationHeader(Exception): pass
 
@@ -24,7 +24,7 @@ class AspenHTTPProvider:
         self.request = request
 
     def _response(self, *args):
-        from aspen import Response
+        from .. import Response
         r = Response(*args)
         r.request = self.request
         return r

--- a/aspen/body_parsers.py
+++ b/aspen/body_parsers.py
@@ -14,11 +14,11 @@ Headers mapping of the supplied headers
 """
 
 import cgi
-from aspen import Response, json_ as json
-from aspen.utils import typecheck
-from aspen.http.request import Headers
-from aspen.http.mapping import Mapping
-from aspen.exceptions import MalformedBody, UnknownBodyType
+from . import json_ as json
+from .utils import typecheck
+from .http.request import Headers
+from .http.mapping import Mapping
+from .exceptions import MalformedBody, UnknownBodyType
 
 def formdata(raw, headers):
     """Parse raw as form data"""

--- a/aspen/configuration/__init__.py
+++ b/aspen/configuration/__init__.py
@@ -17,11 +17,11 @@ import pkg_resources
 from collections import defaultdict
 
 import aspen
-import aspen.logging
-from aspen.configuration import parse
-from aspen.exceptions import ConfigurationError
-from aspen.utils import ascii_dammit
-from aspen.typecasting import defaults as default_typecasters
+from . import parse
+from .. import logging
+from ..exceptions import ConfigurationError
+from ..utils import ascii_dammit
+from ..typecasting import defaults as default_typecasters
 import aspen.body_parsers
 
 
@@ -175,8 +175,8 @@ class Configurable(object):
         # This is initially set to -1 and not 0 so that we can tell if the user
         # changed it programmatically directly before we got here. I do this in
         # the testing module, that's really what this is about.
-        if aspen.logging.LOGGING_THRESHOLD == -1:
-            aspen.logging.LOGGING_THRESHOLD = self.logging_threshold
+        if logging.LOGGING_THRESHOLD == -1:
+            logging.LOGGING_THRESHOLD = self.logging_threshold
         # Now that we know the user's desires, we can log appropriately.
         aspen.log_dammit(os.linesep.join(msgs))
 

--- a/aspen/configuration/parse.py
+++ b/aspen/configuration/parse.py
@@ -13,9 +13,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import aspen
-from aspen.utils import typecheck
-from aspen.http.response import charset_re
+from .. import RENDERERS
+from ..utils import typecheck
+from ..http.response import charset_re
 
 
 def identity(value):
@@ -65,7 +65,7 @@ def list_(value):
 
 def renderer(value):
     typecheck(value, unicode)
-    if value not in aspen.RENDERERS:
-        msg = "not one of {%s}" % (','.join(aspen.RENDERERS))
+    if value not in RENDERERS:
+        msg = "not one of {%s}" % (','.join(RENDERERS))
         raise ValueError(msg)
     return value.encode('US-ASCII')

--- a/aspen/dispatcher.py
+++ b/aspen/dispatcher.py
@@ -12,7 +12,7 @@ from __future__ import unicode_literals
 import mimetypes
 import os
 
-from aspen import Response
+from . import Response
 from .backcompat import namedtuple
 
 

--- a/aspen/exceptions.py
+++ b/aspen/exceptions.py
@@ -9,7 +9,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from aspen import Response
+from . import Response
 
 
 class ConfigurationError(StandardError):

--- a/aspen/http/baseheaders.py
+++ b/aspen/http/baseheaders.py
@@ -8,9 +8,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 
-from aspen.backcompat import CookieError, SimpleCookie
-from aspen.http.mapping import CaseInsensitiveMapping
-from aspen.utils import typecheck
+from ..backcompat import CookieError, SimpleCookie
+from .mapping import CaseInsensitiveMapping
+from ..utils import typecheck
 
 
 def _check_for_CRLF(value):

--- a/aspen/http/mapping.py
+++ b/aspen/http/mapping.py
@@ -29,7 +29,7 @@ class Mapping(dict):
         try:
             return dict.__getitem__(self, name)[-1]
         except KeyError:
-            from aspen import Response
+            from .. import Response
             raise Response(400, "Missing key: %s" % repr(name))
 
     def __setitem__(self, name, value):
@@ -65,7 +65,7 @@ class Mapping(dict):
         try:
             return dict.__getitem__(self, name)
         except KeyError:
-            from aspen import Response
+            from .. import Response
             raise Response(400)
 
     def get(self, name, default=None):

--- a/aspen/http/request.py
+++ b/aspen/http/request.py
@@ -43,10 +43,10 @@ import urllib
 import urlparse
 from cStringIO import StringIO
 
-from aspen import Response
-from aspen.http.baseheaders import BaseHeaders
-from aspen.http.mapping import Mapping
-from aspen.utils import ascii_dammit
+from .. import Response
+from .baseheaders import BaseHeaders
+from .mapping import Mapping
+from ..utils import ascii_dammit
 
 
 # WSGI Do Our Best

--- a/aspen/http/response.py
+++ b/aspen/http/response.py
@@ -12,9 +12,9 @@ import os
 import re
 import sys
 
-from aspen.utils import ascii_dammit
-from aspen.http import status_strings
-from aspen.http.baseheaders import BaseHeaders as Headers
+from ..utils import ascii_dammit
+from . import status_strings
+from .baseheaders import BaseHeaders as Headers
 
 
 class CloseWrapper(object):

--- a/aspen/renderers/json_dump.py
+++ b/aspen/renderers/json_dump.py
@@ -7,10 +7,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from aspen import renderers
-from aspen import json
+from . import Renderer, Factory
+from .. import json
 
-class Renderer(renderers.Renderer):
+class Renderer(Renderer):
     def compile(self, filepath, raw):
         return raw
 
@@ -22,6 +22,6 @@ class Renderer(renderers.Renderer):
         return json.dumps(eval(self.compiled, globals(), context))
 
 
-class Factory(renderers.Factory):
+class Factory(Factory):
     Renderer = Renderer
 

--- a/aspen/renderers/jsonp_dump.py
+++ b/aspen/renderers/jsonp_dump.py
@@ -7,8 +7,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from aspen import renderers
-from aspen.renderers.json_dump import Renderer as JsonRenderer
+from . import Factory
+from .json_dump import Renderer as JsonRenderer
 
 import re
 
@@ -41,5 +41,5 @@ class Renderer(JsonRenderer):
         return "/**/ " + callback + "(" + json + ");"
 
 
-class Factory(renderers.Factory):
+class Factory(Factory):
     Renderer = Renderer

--- a/aspen/renderers/stdlib_format.py
+++ b/aspen/renderers/stdlib_format.py
@@ -7,10 +7,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from aspen import renderers
+from . import Renderer, Factory
 
 
-class Renderer(renderers.Renderer):
+class Renderer(Renderer):
     def compile(self, filepath, raw):
         return raw
 
@@ -18,5 +18,5 @@ class Renderer(renderers.Renderer):
         return self.compiled.format(**context)
 
 
-class Factory(renderers.Factory):
+class Factory(Factory):
     Renderer = Renderer

--- a/aspen/renderers/stdlib_percent.py
+++ b/aspen/renderers/stdlib_percent.py
@@ -7,10 +7,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from aspen import renderers
+from . import Renderer, Factory
 
 
-class Renderer(renderers.Renderer):
+class Renderer(Renderer):
     def compile(self, filepath, raw):
         return raw
 
@@ -18,6 +18,6 @@ class Renderer(renderers.Renderer):
         return self.compiled % context
 
 
-class Factory(renderers.Factory):
+class Factory(Factory):
     Renderer = Renderer
 

--- a/aspen/renderers/stdlib_template.py
+++ b/aspen/renderers/stdlib_template.py
@@ -7,10 +7,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from aspen import renderers
+from . import Renderer, Factory
 from string import Template
 
-class Renderer(renderers.Renderer):
+class Renderer(Renderer):
     def compile(self, filepath, raw):
         return Template(raw)
 
@@ -18,5 +18,5 @@ class Renderer(renderers.Renderer):
         return self.compiled.substitute(context)
 
 
-class Factory(renderers.Factory):
+class Factory(Factory):
     Renderer = Renderer

--- a/aspen/resources/__init__.py
+++ b/aspen/resources/__init__.py
@@ -25,10 +25,10 @@ import stat
 import sys
 import traceback
 
-from aspen.backcompat import StringIO
-from aspen.exceptions import LoadError
-from aspen.resources.simplate import Simplate
-from aspen.resources.static_resource import StaticResource
+from ..backcompat import StringIO
+from ..exceptions import LoadError
+from .simplate import Simplate
+from .static_resource import StaticResource
 
 
 # Cache helpers

--- a/aspen/resources/simplate.py
+++ b/aspen/resources/simplate.py
@@ -11,9 +11,9 @@ import re
 import sys
 
 import mimeparse
-from aspen import Response, log
-from aspen.resources.pagination import split_and_escape, Page, parse_specline
-from aspen.resources.resource import Resource
+from .. import Response, log
+from .pagination import split_and_escape, Page, parse_specline
+from .resource import Resource
 
 
 renderer_re = re.compile(r'[a-z0-9.-_]+$')

--- a/aspen/resources/static_resource.py
+++ b/aspen/resources/static_resource.py
@@ -8,8 +8,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 
-from aspen import Response
-from aspen.resources.resource import Resource
+from .. import Response
+from .resource import Resource
 
 
 class StaticResource(Resource):

--- a/aspen/testing/client.py
+++ b/aspen/testing/client.py
@@ -10,9 +10,9 @@ from __future__ import unicode_literals
 from Cookie import SimpleCookie
 from StringIO import StringIO
 
-from aspen import Response
-from aspen.utils import typecheck
-from aspen.website import Website
+from .. import Response
+from ..utils import typecheck
+from ..website import Website
 
 BOUNDARY = b'BoUnDaRyStRiNg'
 MULTIPART_CONTENT = b'multipart/form-data; boundary=%s' % BOUNDARY

--- a/aspen/testing/harness.py
+++ b/aspen/testing/harness.py
@@ -11,8 +11,8 @@ import os
 import sys
 from collections import namedtuple
 
-from aspen import resources
-from aspen.testing.client import Client
+from .. import resources
+from .client import Client
 from filesystem_tree import FilesystemTree
 
 

--- a/aspen/testing/pytest_fixtures.py
+++ b/aspen/testing/pytest_fixtures.py
@@ -10,7 +10,7 @@ from __future__ import unicode_literals
 import sys
 
 import pytest
-from aspen.testing.harness import Harness
+from .harness import Harness
 from filesystem_tree import FilesystemTree
 
 

--- a/aspen/typecasting.py
+++ b/aspen/typecasting.py
@@ -10,7 +10,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from aspen import Response
+from . import Response
 
 
 class FailedTypecast(Response):

--- a/aspen/website.py
+++ b/aspen/website.py
@@ -11,10 +11,10 @@ import datetime
 import os
 
 from algorithm import Algorithm
-from aspen.configuration import Configurable
-from aspen.http.response import Response
-from aspen.utils import to_rfc822, utc
-from aspen.exceptions import BadLocation
+from .configuration import Configurable
+from .http.response import Response
+from .utils import to_rfc822, utc
+from .exceptions import BadLocation
 
 # 2006-11-17 was the first release of aspen - v0.3
 THE_PAST = to_rfc822(datetime.datetime(2006, 11, 17, tzinfo=utc))

--- a/aspen/wsgi.py
+++ b/aspen/wsgi.py
@@ -15,7 +15,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from aspen.website import Website
+from .website import Website
 
 website = Website()
 application = website  # a number of WSGI servers look for this name by default


### PR DESCRIPTION
Per #454, moved to almost all relative imports.  The exceptions are the configuration module which was more complicated and is going away soon, and `algorithm/website.py` because I wasn't sure how relative imports would interact with the `algorithm.py` module stuff.