### PR TITLE
Add pygments switch 'colorize'

### DIFF
--- a/aspen/configuration/__init__.py
+++ b/aspen/configuration/__init__.py
@@ -41,6 +41,7 @@ KNOBS = \
     , 'project_root':       (None,                  parse.identity)
     , 'renderer_default':   ('stdlib_percent',      parse.renderer)
     , 'show_tracebacks':    (False,                 parse.yes_no)
+    , 'colorize_tracebacks':(True,                  parse.yes_no)
     , 'www_root':           (None,                  parse.identity)
      }
 

--- a/aspen/www/error.spt
+++ b/aspen/www/error.spt
@@ -11,11 +11,11 @@ try:
     from pygments.lexers import PythonTracebackLexer
     from pygments.formatters import HtmlFormatter
     from StringIO import StringIO
-    pygmentize = True
+    pygmentizable = True
 except ImportError:
     from aspen.logging import log
     log("Failed to import pygments. Tracebacks won't be highlighted.")
-    pygmentize = False
+    pygmentizable = False
 
 [----------------------------------------]
 style = ''
@@ -23,7 +23,7 @@ msg = status_strings.get(response.code, 'Sorry')
 msg = msg[0].upper() + msg[1:].lower()
 if website.show_tracebacks:
     err_ascii = response.body
-    if pygmentize:
+    if pygmentizable and website.colorize_tracebacks:
         # Pygments does HTML escaping
         sio = StringIO()
         formatter = HtmlFormatter()

--- a/doc/api/website/index.html.spt
+++ b/doc/api/website/index.html.spt
@@ -26,6 +26,7 @@ arguments to Website:</p>
     <tr><td>project_root</td><td>None</td> </tr>
     <tr><td>renderer_default</td><td>stdlib_percent</td> </tr>
     <tr><td>show_tracebacks</td><td>False</td> </tr>
+    <tr><td>colorize_tracebacks</td><td>False</td> </tr>
     <tr><td>www_root</td><td>None</td> </tr>
     <tr><td>unavailable</td><td>0</td> </tr>
 </table>

--- a/doc/configuration/index.html.spt
+++ b/doc/configuration/index.html.spt
@@ -22,6 +22,7 @@ Here is an example configuration:</p>
     <tr><td>media_type_json</td>            <td>application/json</td> </tr>
     <tr><td>project_root</td>               <td>/usr/local/mysite</td> </tr>
     <tr><td>show_tracebacks</td>            <td>True</td> </tr>
+    <tr><td>colorize_tracebacks</td>        <td>True</td> </tr>
     <tr><td>www_root</td>                   <td>/usr/local/mysite/www</td> </tr>
     <tr><td>unavailable</td>                <td>0</td> </tr>
 </table>


### PR DESCRIPTION
Fixes #266.  As much as I hate adding another config option, it seemed the only way.  Unless we want to just rip out pygments entirely.  It's only used in the error simplate as this point.